### PR TITLE
Update the jpeg-turbo config files

### DIFF
--- a/jconfig.h
+++ b/jconfig.h
@@ -1,13 +1,13 @@
 /* Version ID for the JPEG library.
  * Might be useful for tests like "#if JPEG_LIB_VERSION >= 60".
  */
-#define JPEG_LIB_VERSION 62
+#define JPEG_LIB_VERSION  62
 
 /* libjpeg-turbo version */
-#define LIBJPEG_TURBO_VERSION 2.0.2
+#define LIBJPEG_TURBO_VERSION  2.0.4
 
 /* libjpeg-turbo version in integer form */
-#define LIBJPEG_TURBO_VERSION_NUMBER 2000002
+#define LIBJPEG_TURBO_VERSION_NUMBER  2000004
 
 /* Support arithmetic encoding */
 #define C_ARITH_CODING_SUPPORTED 1

--- a/jconfigint.h
+++ b/jconfigint.h
@@ -1,5 +1,5 @@
 /* libjpeg-turbo build number */
-#define BUILD "20190613"
+#define BUILD  "20200128"
 
 /* Compiler's inline keyword */
 #undef inline
@@ -12,10 +12,10 @@
 #endif
 
 /* Define to the full name of this package. */
-#define PACKAGE_NAME "libjpeg-turbo"
+#define PACKAGE_NAME  "libjpeg-turbo"
 
 /* Version number of package */
-#define VERSION "2.0.2"
+#define VERSION  "2.0.4"
 
 /* The size of `size_t', as reported by the compiler through the
  * builtin macro __SIZEOF_SIZE_T__. If the compiler does not


### PR DESCRIPTION
Add on to https://github.com/Esri/libjpeg-turbo/pull/2

Jpeg will autogenerate config files when you run cmake. The files RTC
uses have been modified for cross-platform consumption with cherry
picked changes from skia. Only pull in config changes pertaining to the
build version.

vTest 3rdparty: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/506/downstreambuildview/
vTest RTC: https://runtime-rtc.esri.com/view/vTest/job/vtest/job/runtimecore-interface/9380/downstreambuildview/