### PR TITLE
arch: Make changes needed for the new premake build structure

### DIFF
--- a/libjpeg-turbo.lua
+++ b/libjpeg-turbo.lua
@@ -1,758 +1,192 @@
 project "jpeg"
 
-  local prj = project()
-  local prjDir = prj.basedir
+dofile(_BUILD_DIR .. "/static_library.lua")
 
-  -- -------------------------------------------------------------
-  -- project
-  -- -------------------------------------------------------------
+configuration { "*" }
 
-  -- common project settings
+uuid "9A746419-F4A6-4D7A-8819-689F1F12C3AF"
 
-  dofile (_BUILD_DIR .. "/3rdparty_static_project.lua")
+includedirs {
+  ".",
+}
 
-  -- project specific settings
+files {
+  "jaricom.c",
+  "jcapimin.c",
+  "jcapistd.c",
+  "jcarith.c",
+  "jccoefct.c",
+  "jccolor.c",
+  "jcdctmgr.c",
+  "jchuff.c",
+  "jcinit.c",
+  "jcmainct.c",
+  "jcmarker.c",
+  "jcmaster.c",
+  "jcomapi.c",
+  "jcparam.c",
+  "jcphuff.c",
+  "jcprepct.c",
+  "jcsample.c",
+  "jctrans.c",
+  "jdapimin.c",
+  "jdapistd.c",
+  "jdarith.c",
+  "jdatadst.c",
+  "jdatasrc.c",
+  "jdcoefct.c",
+  "jdcolor.c",
+  "jddctmgr.c",
+  "jdhuff.c",
+  "jdinput.c",
+  "jdmainct.c",
+  "jdmarker.c",
+  "jdmaster.c",
+  "jdmerge.c",
+  "jdphuff.c",
+  "jdpostct.c",
+  "jdsample.c",
+  "jdtrans.c",
+  "jerror.c",
+  "jfdctflt.c",
+  "jfdctfst.c",
+  "jfdctint.c",
+  "jidctflt.c",
+  "jidctfst.c",
+  "jidctint.c",
+  "jidctred.c",
+  "jmemmgr.c",
+  "jmemnobs.c",
+  "jquant1.c",
+  "jquant2.c",
+  "jutils.c",
+}
 
-  uuid "9A746419-F4A6-4D7A-8819-689F1F12C3AF"
+local opts_simd_none = {
+  "jsimd_none.c",
+}
 
-  flags {
-    "NoPCH",
+local opts_simd_arm = {
+  "simd/arm/jsimd_arm.c",
+  "simd/arm/jsimd_neon_arm.S",
+}
+
+local opts_simd_arm64 = {
+  "simd/arm64/jsimd_arm64.c",
+  "simd/arm64/jsimd_neon_arm64.S",
+}
+
+if (_PLATFORM_ANDROID) then
+  configuration { "*arm64*" }
+
+  defines {
+    "WITH_SIMD",
   }
 
   files {
-    "jaricom.c",
-    "jcapimin.c",
-    "jcapistd.c",
-    "jcarith.c",
-    "jccoefct.c",
-    "jccolor.c",
-    "jcdctmgr.c",
-    "jchuff.c",
-    "jcinit.c",
-    "jcmainct.c",
-    "jcmarker.c",
-    "jcmaster.c",
-    "jcomapi.c",
-    "jcparam.c",
-    "jcphuff.c",
-    "jcprepct.c",
-    "jcsample.c",
-    "jctrans.c",
-    "jdapimin.c",
-    "jdapistd.c",
-    "jdarith.c",
-    "jdatadst.c",
-    "jdatasrc.c",
-    "jdcoefct.c",
-    "jdcolor.c",
-    "jddctmgr.c",
-    "jdhuff.c",
-    "jdinput.c",
-    "jdmainct.c",
-    "jdmarker.c",
-    "jdmaster.c",
-    "jdmerge.c",
-    "jdphuff.c",
-    "jdpostct.c",
-    "jdsample.c",
-    "jdtrans.c",
-    "jerror.c",
-    "jfdctflt.c",
-    "jfdctfst.c",
-    "jfdctint.c",
-    "jidctflt.c",
-    "jidctfst.c",
-    "jidctint.c",
-    "jidctred.c",
-    "jmemmgr.c",
-    "jmemnobs.c",
-    "jquant1.c",
-    "jquant2.c",
-    "jutils.c",
+    opts_simd_arm64,
   }
 
-  includedirs {
-    "./",
+  configuration { "*armv7*" }
+
+  defines {
+    "WITH_SIMD",
   }
 
-  local opts_simd_none = {
-    "jsimd_none.c",
+  files {
+    opts_simd_arm,
   }
 
-  local opts_simd_arm = {
-    "simd/arm/jsimd_arm.c",
-    "simd/arm/jsimd_neon_arm.S",
+  configuration { "*x64*" }
+
+  files {
+    opts_simd_none,
   }
 
-  local opts_simd_arm64 = {
-    "simd/arm64/jsimd_arm64.c",
-    "simd/arm64/jsimd_neon_arm64.S",
+  configuration { "*x86*" }
+
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_COCOA) then
+  configuration { "*arm64*" }
+
+  defines {
+    "WITH_SIMD",
   }
 
-  -- -------------------------------------------------------------
-  -- configurations
-  -- -------------------------------------------------------------
-
-  if (_PLATFORM_WINDOWS) then
-    -- -------------------------------------------------------------
-    -- configuration { "windows" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/3rdparty_static_win.lua")
-
-    -- project specific configuration settings
-
-    configuration { "windows" }
-
-      defines {
-        "TURBO_FOR_WINDOWS",
-      }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x86_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x86_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_LINUX) then
-    -- -------------------------------------------------------------
-    -- configuration { "linux" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux.lua")
-
-    -- project specific configuration settings
-
-    configuration { "linux" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Debug", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Debug", "ARM64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Release", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Release", "ARM64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_MACOS) then
-    -- -------------------------------------------------------------
-    -- configuration { "macosx" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac.lua")
-
-    -- project specific configuration settings
-
-    configuration { "macosx" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_COCOA) then
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa*" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "cocoa*" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_arm64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_arm64_debug" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_arm64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_arm64_release" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_sim64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_sim64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_sim64_debug" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_sim64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_sim64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_sim64_release" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_x64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_x64_debug" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "cocoa_x64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_cocoa_x64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "cocoa_x64_release" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_IOS) then
-    -- -------------------------------------------------------------
-    -- configuration { "ios*" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_ios.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "ios*" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "ios_arm64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_ios_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "ios_arm64_debug" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "ios_arm64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_ios_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "ios_arm64_release" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "ios_sim64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_ios_sim64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "ios_sim64_debug" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "ios_sim64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_ios_sim64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "ios_sim64_release" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_ANDROID) then
-    -- -------------------------------------------------------------
-    -- configuration { "android*" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "android*" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_armv7_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_armv7_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_armv7_debug" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_armv7_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_armv7_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_armv7_release" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_x86_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_x86_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_x86_debug" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_x86_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_x86_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_x86_release" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_arm64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_arm64_debug" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_arm64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_arm64_release" }
-
-      defines {
-        "WITH_SIMD",
-      }
-
-      files {
-        opts_simd_arm64,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_x64_debug" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_x64_debug" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "android_x64_release" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_android_x64_release.lua")
-
-    -- project specific configuration settings
-
-    configuration { "android_x64_release" }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_WINUWP) then
-    -- -------------------------------------------------------------
-    -- configuration { "windows" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp.lua")
-
-    -- project specific configuration settings
-
-    configuration { "windows" }
-
-      defines {
-        "TURBO_FOR_WINDOWS",
-        "_CRT_SECURE_NO_WARNINGS",
-      }
-
-      files {
-        opts_simd_none,
-      }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_debug", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_x86_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_debug", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_release", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_x86_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_release", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_release", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_debug", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_debug", "ARM64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "winuwp_release", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_winuwp_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "winuwp_release", "ARM64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_IS_QT) then
-    -- -------------------------------------------------------------
-    -- configuration { "qt" }
-    -- -------------------------------------------------------------
-
-    local qt_include_dirs = PROJECT_INCLUDE_DIRS
-
-    -- Add additional QT include dirs
-    -- table.insert(qt_include_dirs, <INCLUDE_PATH>)
-
-    createqtfiles(project(), qt_include_dirs)
-
-    -- -------------------------------------------------------------
-  end
+  files {
+    opts_simd_arm64,
+  }
+
+  configuration { "*x64*" }
+
+  files {
+    opts_simd_none,
+  }
+
+  configuration { "*sim64*" } -- remove once sim64 is simx64
+
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_IOS) then
+  configuration { "*arm64*" }
+
+  defines {
+    "WITH_SIMD",
+  }
+
+  files {
+    opts_simd_arm64,
+  }
+
+  configuration { "*x64*" }
+
+  files {
+    opts_simd_none,
+  }
+
+  configuration { "*sim64*" } -- remove once sim64 is simx64
+
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_LINUX) then
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_MACOS) then
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_WINDOWS) then
+  defines {
+    "TURBO_FOR_WINDOWS",
+  }
+
+  files {
+    opts_simd_none,
+  }
+end
+
+if (_PLATFORM_WINUWP) then
+  defines {
+    "TURBO_FOR_WINDOWS",
+    "_CRT_SECURE_NO_WARNINGS",
+  }
+
+  files {
+    opts_simd_none,
+  }
+end


### PR DESCRIPTION
The premake build structure has been simplified and rewritten to reduce
the boilerplate needed to add additional configurations while forcing
the unique settings of a project to be defined. Migrate some defines
and compiler options to the global settings and remove all the old
boilerplate from this project.

Issue-number: https://devtopia.esri.com/runtime/devops/issues/830